### PR TITLE
兼容GotoSocial

### DIFF
--- a/src/function.php
+++ b/src/function.php
@@ -64,6 +64,9 @@ function ActivityPub_Verification($input = null, $pull = true) {
             $pdo->execute([':actor' => $actor]);
             if ($public_key = $pdo->fetch(PDO::FETCH_COLUMN, 0)) {
                 $signed_string = '(request-target): '.strtolower($_SERVER['REQUEST_METHOD']).' '.$_SERVER['REQUEST_URI'];
+                if ($signature['algorithm'] == 'hs2019') {
+                    $signature['algorithm'] = 'rsa-sha256';
+                }
                 foreach (array_slice($headers, 1) as $header) $signed_string .= "\n".$header.': '.$_SERVER['HTTP_'.strtoupper(str_replace('-','_',$header))];
                 if (openssl_verify($signed_string, base64_decode($signature['signature']), $public_key, $signature['algorithm'])) {
                     if (isset($_SERVER['HTTP_DIGEST'])) {

--- a/src/function.php
+++ b/src/function.php
@@ -180,6 +180,8 @@ function Club_Announce_Process($jsonld) {
     $pdo = $db->prepare('select `id` from `activities` where `object` = :object');
     $pdo->execute([':object' => $jsonld['object']['id']]);
     if (!$pdo->fetch(PDO::FETCH_ASSOC)) {
+        $jsonld['to'] = (is_array($jsonld['to']) ? $jsonld['to'] : array($jsonld['to']));
+        $jsonld['cc'] = (is_array($jsonld['cc']) ? $jsonld['cc'] : array($jsonld['cc']));
         foreach ($to = array_merge($jsonld['to'], $jsonld['cc']) as $cc)
             if (($club_url = $base.'/club/') == substr($cc, 0, strlen($club_url)))
                 if ($club = Club_Exist(explode('/', substr($cc, strlen($club_url)))[0])) $clubs[$club] = 1;

--- a/src/function.php
+++ b/src/function.php
@@ -58,7 +58,8 @@ function ActivityPub_Verification($input = null, $pull = true) {
         preg_match_all('/[,\s]*(.*?)="(.*?)"/', $_SERVER['HTTP_SIGNATURE'], $matches);
         foreach ($matches[1] as $k => $v) $signature[$v] = $matches[2][$k];
         if (($headers = explode(' ', $signature['headers']))[0] == '(request-target)') {
-            $actor = explode('#', $signature['keyId'])[0];
+            $url_parts = parse_url($signature['keyId']);
+            $actor = $url_parts['scheme'] . '://' . $url_parts['host'] . '/' . explode('/', $url_parts['path'])[1] . '/' . explode('/', $url_parts['path'])[2];
             $pdo = $db->prepare('select `public_key` from `users` where `actor` = :actor');
             $pdo->execute([':actor' => $actor]);
             if ($public_key = $pdo->fetch(PDO::FETCH_COLUMN, 0)) {


### PR DESCRIPTION
此PR根据 #5 中的 [debug结果](https://github.com/wxwmoe/wxwClub/issues/5#issuecomment-1918395757) 添加对应修复，使GotoSocial能够与wxwClub互联。

1. Gotosocial 的 actor 和 main key之间是用 / 而不是用 # 隔开的。 8f55a8dd06a619b5a2d8330734ee6f9c970305af 修改对`$signature['keyId']`的切分和拼接逻辑解决这一问题。
2. Gotosocial 发送的 signature 中 algorithm 字段使用的是 hs2019 并默认用 rsa-sha256 签名，wxwClub 目前只接受明确指定的算法，遇到这种情形没有 fallback。 f2a1ec85a5b8b485056934f18a8323fe900d266b 在执行 `openssl_verify()` 前检查`algorithm`字段，若为`hs2019`则fallback到`rsa-sha256`（包括Mastodon和Gotosocial在内的AP服务端均使用此算法签名）
3. 收到 mention 时，GotoSocial 的 to 字段有可能不是数组，而 wxwClub 的 Announce Process 只支持数组情形。 658673f2b3f154e9942279b11380586887313bb7 在 `$jsonld['to']` 和 `$jsonld['cc']` 为字符串是将其提前转换为数组。
4. GotoSocial的follow request发送到的是wxwClub的shared inbox 而非 特定club的inbox。 4c699de42ca3dac51ac12935dda381b799c40a79 在 `/inbox` 下添加了对 `Follow` 和 `Undo` 的支持。在此情形下，先从`$jsonld['object']`解析出对应`club`并构建`club_url`，然后执行与`/club`下类似的流程。

---

This PR adds corresponding fixes based on the [debug results](https://github.com/wxwmoe/wxwClub/issues/5#issuecomment-1918395757) in #5, enabling GotoSocial to federate with wxwClub.

1. In GotoSocial, the actor and main key are separated by `/` instead of `#`. Commit 8f55a8dd06a619b5a2d8330734ee6f9c970305af modifies the splitting and concatenating logic of `$signature['keyId']` to support both delimeters.
2. The signature sent by GotoSocial uses `hs2019` for the algorithm field and defaults to `rsa-sha256` for signing. Currently, wxwClub only accepts explicitly specified algorithms and does not have a fallback for this situation. Commit f2a1ec85a5b8b485056934f18a8323fe900d266b checks the algorithm field before executing openssl_verify(), and if it is `hs2019`, it falls back to `rsa-sha256` (this algorithm is used for signing by AP servers including Mastodon and GotoSocial).
3. When receiving a mention, the `to` field in GotoSocial's request might not be an array, while wxwClub‘s Announce Process only supports array scenarios. Commit 658673f2b3f154e9942279b11380586887313bb7 converts `$jsonld['to']` and `$jsonld['cc']` to arrays beforehand if they are strings.
4. The follow/unfollow request from GotoSocial is sent to the shared inbox of wxwClub rather than the inbox of a specific club. Commit 4c699de42ca3dac51ac12935dda381b799c40a79 adds support for type `Follow` and `Undo` under `/inbox`. In this case, the corresponding club is first parsed from `$jsonld['object']` and construct club_url, and then a process similar to that under /club is executed.