### PR TITLE
添加blocklist支持

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -20,6 +20,7 @@ if ($config['nodeDebugging']) {
     if (!is_dir('logs')) mkdir('logs');
     if (!is_dir('logs/curl')) mkdir('logs/curl');
     if (!is_dir('logs/error')) mkdir('logs/error');
+    if (!is_dir('logs/blocklist')) mkdir('logs/blocklist');
     ini_set('error_log', 'logs/error/'.date('Y-m-d_H:i:s').'_error.log');
 }
 
@@ -28,6 +29,48 @@ try {
         $config['mysql']['username'], $config['mysql']['password'], [PDO::ATTR_PERSISTENT => true]);
     if (isset($argv[1])) switch ($argv[1]) {
         case 'worker': echo date('[Y-m-d H:i:s]').' Start running worker ...',"\n"; while (!$stop) worker(); echo date('[Y-m-d H:i:s]').' Worker stopped',"\n"; break;
+        case 'block':
+            if (isset($argv[2]) && isset($argv[3])) {
+                $type = $argv[2];
+                $target = $argv[3];
+                $club = isset($argv[4]) ? $argv[4] : null;
+                block($type, $target, $club);
+            } else {
+                echo "Usage: php cli.php block <user|instance> <target> [<club>]\n";
+            }
+            break;
+        case 'unblock':
+            if (isset($argv[2]) && isset($argv[3])) {
+                $type = $argv[2];
+                $target = $argv[3];
+                $club = isset($argv[4]) ? $argv[4] : null;
+                unblock($type, $target, $club);
+            } else {
+                echo "Usage: php cli.php unblock <user|instance> <target> [<club>]\n";
+            }
+            break;
+        case 'list-blocks':
+            $club = isset($argv[2]) ? $argv[2] : null;
+            listBlocks($club);
+            break;
+        case 'export-blocks':
+            $club = isset($argv[2]) ? $argv[2] : null;
+            exportBlocks($club);
+            break;
+        case 'import-blocks':
+            if (isset($argv[2]) && isset($argv[3])) {
+                $type = $argv[2];
+                $file_path = $argv[3];
+                $club = isset($argv[4]) ? $argv[4] : null;
+                if ($type !== 'user' && $type !== 'instance') {
+                    echo "Error: Type must be 'user' or 'instance'.\n";
+                } else {
+                    importBlocks($type, $file_path, $club);
+                }
+            } else {
+                echo "Usage: php cli.php import-blocks <user|instance> <file_path> [<club>]\n";
+            }
+            break;
         default: echo 'Unknown parameters',"\n"; break;
     }
 } catch (PDOException $e) {

--- a/index.php
+++ b/index.php
@@ -13,6 +13,7 @@ if ($config['nodeDebugging']) {
     if (!is_dir('logs/inbox')) mkdir('logs/inbox');
     if (!is_dir('logs/outbox')) mkdir('logs/outbox');
     if (!is_dir('logs/webfinger')) mkdir('logs/webfinger');
+    if (!is_dir('logs/blocklist')) mkdir('logs/blocklist');
     ini_set('error_log', 'logs/error/'.date('Y-m-d_H:i:s').'_error.log');
 }
 

--- a/tools/wxwclub.sql
+++ b/tools/wxwclub.sql
@@ -111,3 +111,27 @@ CREATE TABLE `blacklist` (
   KEY `timestamp` (`timestamp`),
   KEY `inuse` (`inuse`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Migration: 20241024
+
+CREATE TABLE `users_blocks` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `club_id` int DEFAULT NULL,
+  `target` varchar(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `created_at` int NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `club_target` (`club_id`, `target`),
+  KEY `club_id` (`club_id`),
+  CONSTRAINT `users_blocks_ibfk_1` FOREIGN KEY (`club_id`) REFERENCES `clubs` (`cid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `instances_blocks` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `club_id` int DEFAULT NULL,
+  `target` varchar(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `created_at` int NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `club_target` (`club_id`, `target`),
+  KEY `club_id` (`club_id`),
+  CONSTRAINT `instances_blocks_ibfk_1` FOREIGN KEY (`club_id`) REFERENCES `clubs` (`cid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
此PR为wxwClub添加了基本的blocklist管理功能：

## 动机

昨天 board 公共留言板遭遇恶意用户发送多条骚扰信息。另外我在日常浏览中曾多次看到有用户抱怨board被滥用。所以实现并提出了此PR。如果通过测试并实装，希望能够减少对board的滥用。

## 新增功能

1. 支持增删针对用户和实例的blocklist
2. 支持全局屏蔽和针对特定club的屏蔽
3. 提供cli command进行屏蔽管理
4. 支持blocklist的导入和导出功能

实例屏蔽包括实例域名和该域名下所有子域，屏蔽检查发生在`Club_Announce_Process`时，对actor进行blocklist匹配。

## 数据库变更

创建新表`users_blocks`和`instances_blocks`。由于wxwClub目前只有单个SQL文件，不提供迁移支持，在创建新表的指令前添加了对应注释和日期以供区分。

1. 在`cli.php`中添加了新的命令行选项，用于管理屏蔽列表
2. 在`src/function.php`中实现了屏蔽相关的核心功能
3. 更新了数据库结构，添加了`users_blocks`和`instances_blocks`表
4. 在活动处理逻辑中集成了屏蔽检查

## CLI 变更

添加以下 CLI 命令来管理 blocklist：

1. 添加单条屏蔽规则：
  - `php cli.php block user <user> [<club>]`
  - `php cli.php block instance <instance> [<club>]`

2. 移除单条屏蔽规则：
  - `php cli.php unblock user <user> [<club>]`
  - `php cli.php unblock instance <instance> [<club>]`

3. 列出屏蔽规则：
  - `php cli.php list-blocks [<club>]`

4. 导出屏蔽规则：
  - `php cli.php export-blocks [<club>]`

6. 批量导入屏蔽规则（支持去重）：
  - `php cli.php import-blocks <user|instance> <file_path> [<club>]`

## TODO
1. 当前blocklist仅作静默过滤。后续应考虑发送`Reject`回应或在特定endpoint公开blocklist。
2. 由于可运行多个wxwClub worker 队列，难以将数据库查询缓存到内存中，可能后续借助 redis 等会方便一些。
